### PR TITLE
Changes to PropTypes, remove console

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "autobind-decorator": "^1.3.4",
+    "prop-types": "^15.6.2",
     "ramda": "^0.23.0",
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2"

--- a/src/SortableContainer.js
+++ b/src/SortableContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import autobind from 'autobind-decorator'
 import R from 'ramda'
 import { DropTarget, DragDropContext } from 'react-dnd'
@@ -23,7 +24,6 @@ const itemTarget = {
 @DropTarget(itemType, itemTarget, connectDropTarget)
 class SortableContainer extends React.Component {
   static propTypes = {
-    connectDropTarget: PropTypes.func.isRequired,
     collection: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     Component: PropTypes.func.isRequired

--- a/src/SortableItem.js
+++ b/src/SortableItem.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import React from 'react'
 import R from 'ramda'
 import autobind from 'autobind-decorator'
 import { DragSource, DropTarget } from 'react-dnd'
@@ -69,7 +70,7 @@ class SortableItem extends React.Component {
     Component: PropTypes.func.isRequired,
     connectDragPreview: PropTypes.func.isRequired,
     connectDragSource: PropTypes.func.isRequired,
-    connectDropTarget: PropTypes.func.isRequired,
+    connectDropTarget: PropTypes.func,
     index: PropTypes.number.isRequired,
     isDragging: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
@@ -85,8 +86,6 @@ class SortableItem extends React.Component {
   render () {
     const { Component, isDragging, value, onChange, onRemove, index, connectDragSource } = this.props
     const opacity = isDragging ? 0 : 1
-
-    console.log('render SortableItem')
 
     return this.decorateSortableItemElement(
       <div style={{opacity}}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,6 +2852,10 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@3.x, js-yaml@^3.4.3, js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -3135,6 +3139,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -3589,7 +3599,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4133,6 +4143,13 @@ promise@7.1.1, promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~1.1.2:
   version "1.1.3"


### PR DESCRIPTION
This PR does the following

- Uses the `prop-types` module for PropTypes (hopefully to support React 16)
- Remove the `connectDropTarget` prop requirement for `SortableContainer` (it appears to never be used anyways)
- Make `connectDropTarget` optional for `SortableItem`, since it seems like it is safe to omit (for example, it appears like it is not passed as a prop in `SortableContainer.renderItem`)