### PR TITLE
Supporting for React 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # react-drag-sort
 
-*This fork of [react-drag-sort](https://github.com/amonks/react-drag-sort) adds support to react 16. It updates reference of* **PropTypes** *from 'react' to 'prop-types' module, as per the changes to [prop-types support](https://reactjs.org/docs/typechecking-with-proptypes.html)*
-
 generic component for draggable sort
 
 based on react-dnd

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # react-drag-sort
 
+*This fork of [react-drag-sort](https://github.com/amonks/react-drag-sort) adds support to react 16. It updates reference of* **PropTypes** *from 'react' to 'prop-types' module, as per the changes to [prop-types support](https://reactjs.org/docs/typechecking-with-proptypes.html)*
+
 generic component for draggable sort
 
 based on react-dnd

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && npm clean-demo",
-    "start": "nwb serve-react-demo"
+    "start": "nwb serve-react-demo",
+    "postinstall": "yarn build"
   },
   "dependencies": {
     "autobind-decorator": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "autobind-decorator": "^1.3.4",
+    "prop-types": "^15.6.1",
     "ramda": "^0.23.0",
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2"

--- a/src/SortableContainer.js
+++ b/src/SortableContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 import autobind from 'autobind-decorator'
 import R from 'ramda'
 import { DropTarget, DragDropContext } from 'react-dnd'

--- a/src/SortableItem.js
+++ b/src/SortableItem.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types';
 import R from 'ramda'
 import autobind from 'autobind-decorator'
 import { DragSource, DropTarget } from 'react-dnd'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2062,6 +2062,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
@@ -3130,7 +3142,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3589,7 +3601,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4133,6 +4145,14 @@ promise@7.1.1, promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~1.1.2:
   version "1.1.3"


### PR DESCRIPTION
 Adding support to react 16. It updates the reference of* **PropTypes** *from 'react' to 'prop-types' module, as per the changes to prop-types support [https://reactjs.org/docs/typechecking-with-proptypes.html]( https://reactjs.org/docs/typechecking-with-proptypes.html).